### PR TITLE
Update the SASS parser to provide a relevant include-path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ dev-server:
 # Build SASS
 ##
 sass:
-	sass --style compressed --update static/css
+	sass -I node_modules --style compressed --update static/css
 
 ##
 # Run SASS watcher
@@ -89,7 +89,7 @@ sass:
 # - Auto-compiles SASS files to CSS on changes
 ##
 watch-sass:
-	sass --debug-info --watch static/css &
+	sass -I node_modules --debug-info --watch static/css &
 
 ##
 # Get virtualenv ready

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -1,6 +1,6 @@
 // import required files
 
-@import '../../node_modules/cloud-vanilla-theme/scss/build';
+@import 'cloud-vanilla-theme/scss/build';
 @import '../scss/base/buttons';
 @import '../scss/base/footer';
 @import '../scss/base/forms';


### PR DESCRIPTION
## Done
Updated the Sass commands to include node_modules. Changed to theme path to be relative.

## QA
- Pull down the branch
- Run `make clean`
- Run `make setup`
- Run `npm i`
- Run `make develop`
- Check there are no errors and the site looks ok

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/58#issuecomment-287823563
