### PR TITLE
Update get-started section on tour page

### DIFF
--- a/templates/tour.html
+++ b/templates/tour.html
@@ -116,11 +116,14 @@
                          {{ ASSET_SERVER_URL }}d75c6d99-subnets.png?w=400  400w"
                  class="image--shadow" alt="">
             </div>
-            <div class="twelve-col align-center">
-				<p class="align-center">
-					<a href="/get-started" class="button--primary button--large">Get started</a>
-				</p>
-			</div>
+        </div>
+    </section>
+    <section class="row strip-dark">
+        <div class="inner-wrapper">
+            <div class="twelve-col cta">
+                <h3 class="cta__text">MAAS is a bare-metal server provisioning tool. It is open source and free to use.</h3>
+                <a href="/get-started" class="button--primary cta__link">Get started</a>
+            </div>
         </div>
     </section>
 {% endblock %}


### PR DESCRIPTION
## Done
Updated the get-started section at the bottom of the tour page

## QA
- Pull down the branch
- Run `make develop`
- Go to http://127.0.0.1:8000/tour
- Scroll to the bottom section
- Check it matches the /how-it-works page

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/22

## Screenshots
![10538869](https://cloud.githubusercontent.com/assets/1413534/24303813/455ca664-10af-11e7-9187-e2b32c06cb07.png)

