### PR TITLE
Fix spelling of premises on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
 				<h1>
 					<img src="{{ ASSET_SERVER_URL }}33b96a7f-maas-logo.svg" alt="" class="row-hero__logo" itemprop="image" />Metal as a Service
 					<br/>Say hello to your physical cloud</h1>
-				<p class="intro padding-bottom--30" itemprop="description">Total automation of your physical servers for amazing data centre operational efficiency. On premise, open source and supported.</p>
+				<p class="intro padding-bottom--30" itemprop="description">Total automation of your physical servers for amazing data centre operational efficiency. On premises, open source and supported.</p>
 				<p>
 					<a href="/get-started" class="row-hero__cta button--primary" itemprop="url">Get started</a>
 					<a class="row-hero__play venobox" data-type="youtube" data-autoplay="true" href="https://www.youtube.com/embed/J1XH0SQARgo">


### PR DESCRIPTION
## Done
Added a `s` to the end of premises on the homepage hero strip

## QA
- Pull down the branch
- Run `make develop`
- Go to http://127.0.0.1:8000/
- Check that the hero now says premises

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/33