### PR TITLE
Replace duplicate occurrences of Docs in the footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ django-error.log
 /node_modules/
 /tmp/
 cache.sqlite
+npm-debug.log

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -44,7 +44,7 @@
             <a class="footer__link external" href="https://launchpad.net/maas">Launchpad</a>
           </li>
           <li>
-            <a class="footer__link external" href="http://docs.ubuntu.com/maas/">Docs</a>
+            <a class="footer__link external" href="https://docs.ubuntu.com/maas/devel/en/contributing">Contribute to documentation</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done
Replaced the docs link in the footer with a Contribute to documentation link. Add npmlog file to npmignore.

## QA
- Pull this branch
- Run make develop
- Scroll down to the footer
- Check there is Docs in the site footer and a Contribute to documentation link in the Contribute section

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/99