### PR TITLE
Update content in Pricing section on homepage

### DIFF
--- a/static/scss/objects/_pricing.scss
+++ b/static/scss/objects/_pricing.scss
@@ -9,18 +9,26 @@
 @mixin maas-pricing {
   .pricing {
 
-    .pricing__option {
+    &__option {
       padding: 30px;
       border: 1px solid #d2d2d2;
       border-radius: 3px;
 
-      .pricing__option-title {
-        font-size: 1.75em;
+      &-title {
+        font-size: 1.25em;
         margin-bottom: 12px;
+
+        @media only screen and (min-width: $breakpoint-medium) {
+          font-size: 1.5em;
+        }
+
+        @media only screen and (min-width: $breakpoint-large) {
+          font-size: 1.75em;
+        }
       }
 
-      .pricing__option-cost {
-        font-size: 1.75em;
+      &-cost {
+        font-size: 1.25em;
         text-align: left;
         color: $cool-grey;
         font-weight: 300;
@@ -28,13 +36,21 @@
         padding-top: 12px;
         margin-top: 12px;
 
-        .pricing__option-unit {
-          font-size: .75em;
-          color: #666;
+        @media only screen and (min-width: $breakpoint-medium) {
+          font-size: 1.5em;
+        }
+
+        @media only screen and (min-width: $breakpoint-large) {
+          font-size: 1.75em;
         }
       }
 
-      .pricing__option-detail {
+      &-unit {
+        font-size: .75em;
+        color: #666;
+      }
+
+      &-detail {
         border-top: 1px solid #d2d2d2;
         padding: 15px 0 0;
         box-sizing: border-box;

--- a/static/scss/objects/_pricing.scss
+++ b/static/scss/objects/_pricing.scss
@@ -30,7 +30,7 @@
 
         .pricing__option-unit {
           font-size: .75em;
-          color: #d2d2d2;
+          color: #666;
         }
       }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -181,7 +181,7 @@
 					<h4 class="pricing__option-cost">Free</h4>
 					<div class="pricing__option-detail">
 						<ul class="list__bullets">
-							<li>Ubuntu, CentOS</li>
+							<li>Ubuntu and CentOS</li>
 						</ul>
 						<p><a href="/get-started">Get started&nbsp;&rsaquo;</a></p>
 					</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -181,7 +181,7 @@
 					<h4 class="pricing__option-cost">Free</h4>
 					<div class="pricing__option-detail">
 						<ul class="list__bullets">
-							<li>Ubuntu, CentOS, custom images</li>
+							<li>Ubuntu, CentOS</li>
 						</ul>
 						<p><a href="/get-started">Get started&nbsp;&rsaquo;</a></p>
 					</div>
@@ -195,6 +195,7 @@
 						<ul class="list__bullets">
 							<li>All operating systems</li>
 							<li>9 to 5 support on weekdays (US and Europe only)</li>
+							<li>Custom images</li>
 						</ul>
 						<p><a href="/contact-us">Contact us&nbsp;&rsaquo;</a></p>
 					</div>
@@ -208,6 +209,7 @@
 						<ul class="list__bullets">
 							<li>All operating systems</li>
 							<li>24/7 support</li>
+							<li>Custom images</li>
 						</ul>
 						<p><a href="/contact-us">Contact us&nbsp;&rsaquo;</a></p>
 					</div>


### PR DESCRIPTION
## Done
Moved custom images to Professional and Enterprise. Remove custom image from Self-supported. Made unit details more visible.

## QA
- Pull branch
- Run `make develop`
- Go to http://127.0.0.1:8000/
- Scroll down to the "Pricing" section
- Check that "custom images" have been removed from Self-supported.
- Check that "custom images" are both new items on Professional and Enterprise.
- Check that the unit details are now visible `#666`.

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/103

## Screenshots
![10550730](https://cloud.githubusercontent.com/assets/1413534/24631454/43949b50-18b8-11e7-9f41-b6067fe7f81a.png)

