### PR TITLE
Update logos & fonts

### DIFF
--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -8,6 +8,7 @@
 <link rel="shortcut icon" href="{{ ASSET_SERVER_URL }}55e92155-maas.ico" type="image/x-icon" />
 
 <!-- stylesheets -->
+<link href='https://fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic%7CUbuntu+Mono' rel='stylesheet' type='text/css' />
 <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static css_file %}" />
 
 <meta name="twitter:card" content="summary">

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,7 +116,7 @@
 			<div class="six-col last-col">
 				<ul class="inline-logos">
 					<li class="inline-logos__item">
-						<img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}c037fd75-ubuntu-logo.png"  width="150" alt="Ubuntu logo">
+						<img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}adac6928-ubuntu.svg"  width="150" alt="Ubuntu logo">
 					</li>
 					<li class="inline-logos__item">
 						<img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}30574235-windows-logo.svg" width="120" alt="Windows logo">


### PR DESCRIPTION
## Done

- Updates the Ubuntu logo for the 'manage bear metal' row on the home page
- Includes missing fonts via Google Fonts so users who don't have the Ubuntu fonts can see the site as intended

## QA

Pull down the branch and do ```./run``` view the home page and check all fonts have loaded

## Issue / Card
#125 #124 
