### PR TITLE
Spell RHEL correctly and uppercased SUSE

### DIFF
--- a/templates/tour.html
+++ b/templates/tour.html
@@ -128,8 +128,8 @@
                     </div>
                     <div class="three-col last-col">
                         <ul>
-                            <li>REHL</li>
-                            <li>Suse</li>
+                            <li>RHEL</li>
+                            <li>SUSE</li>
                         </ul>
                     </div>
                     <div class="six-col">


### PR DESCRIPTION
## Done
Spell RHEL correctly and uppercased SUSE

## QA
- Pull the branch and run `./run`
- Go to the tour page
- See that RHEL is spelt correctly and SUSE is all uppercase

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/135
