### PR TITLE
Use v0.1.7 of canonicalwebteam.get-feeds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.versioned-static==1.0.1
 canonicalwebteam.yaml-redirects==1.0.2
-canonicalwebteam.get-feeds==0.1.5
+canonicalwebteam.get-feeds==0.1.7
 Django==1.11.1
 django-versioned-static-url==0.1
 django-static-root-finder==0.1


### PR DESCRIPTION
Keep all sites on latest version, for best error handling.

QA
--

`./run`, check feeds still load