### PR TITLE
Update docs links in footer

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -13,7 +13,7 @@
                     <a class="p-link--strong" href="/how-it-works">How it works</a>
                 </li>
                 <li class="p-list__item">
-                    <a class="p-link--external p-link--strong" href="http://docs.ubuntu.com/maas/">Docs</a>
+                    <a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/maas/2.2/en/">Docs</a>
                 </li>
                 <li class="p-list__item">
                     <a class="p-link--strong"  href="/tour">Tour</a>
@@ -46,7 +46,7 @@
                     <a class="p-link--external p-link--strong" href="https://launchpad.net/maas">Launchpad</a>
                 </li>
                 <li class="p-list__item">
-                    <a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/maas/devel/en/contributing">Contribute to documentation</a>
+                    <a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/maas/2.2/en/contributing-writing">Contribute to documentation</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Related to #99.

For now, since there is no mechanism for properly linking to the latest
version, I'm hard-coding version 2.2 in the URL, which is the latest version of
MAAS.

For the time being this will need to be updated manually when a new
version of MAAS is released.

QA
--

`./run` and go to http://0.0.0.0:8006/, check the "Docs" and "Contribute to documentation" links in the footer take you to valid pages on the latest version of MAAS documentation.