### PR TITLE
Logos update on maas.io

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -221,9 +221,6 @@
 						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}040783dd-verizon-logo.png" alt="Verizon logo" />
 					</li>
 					<li class="p-inline-images__item">
-						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}0f6861b9-oil-logo.png" alt="OpenStack Interoperability Lab">
-					</li>
-					<li class="p-inline-images__item">
 						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3c7e83fc-atandt-logo.svg" alt="AT&amp;T logo" />
 					</li>
 					<li class="p-inline-images__item">
@@ -231,6 +228,12 @@
 					</li>
 					<li class="p-inline-images__item">
 						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}73135672-ntt-logo.svg" alt="NTT logo" />
+					</li>
+					<li class="p-inline-images__item">
+						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}82618589-Dell_Logo.svg" alt="Dell logo" />
+					</li>
+					<li class="p-inline-images__item">
+						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}65d21ae8-SKY_Logo.svg" alt="Sky logo" />
 					</li>
 				</ul>
   		</div>

--- a/templates/tour.html
+++ b/templates/tour.html
@@ -10,9 +10,6 @@
         <h1>Take a tour</h1>
         <p class="p-heading--three" itemprop="description">Take a tour and get an overview of MAAS, including new features from the latest release.</p>
       </div>
-      <div class="col-4 prefix-2">
-        <img src="{{ ASSET_SERVER_URL }}381e216f-MAAS-GUI.svg?w=154" width="154" alt="MAAS user interface icon" />
-      </div>
     </div>
 </section>
 


### PR DESCRIPTION
## Done

Update logos 'MAAS is used by' section on home page
Remove hero picto on /tour

- Remove OIL logo
- Dell logo - https://assets.ubuntu.com/v1/82618589-Dell_Logo.svg
- Sky logo - https://assets.ubuntu.com/v1/65d21ae8-SKY_Logo.svg

## QA

- ./run
- Go to http://0.0.0.0:8006/ and make sure the icons match the requested
- Go to /tour and make sure the hero picto has gone

## Issue / Card

Issue: https://github.com/canonical-websites/maas.io/issues/190