### PR TITLE
Replace apt-get with apt

### DIFF
--- a/templates/install.html
+++ b/templates/install.html
@@ -42,7 +42,7 @@
                 </h3>
                 <div class="p-list-step__content">
                   <p class="p-code-snippet">
-                      <input class="p-code-snippet__input" value="sudo apt-get update" readonly="readonly">
+                      <input class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
                       <button class="p-code-snippet__action">Copy to clipboard</button>
                   </p>
                   <p class="p-code-snippet">


### PR DESCRIPTION
## Done
Replaced the `apt-get` command with `apt` on the install page.

## QA
- Go to `/install`
- Check that all apt commands are `apt` not `apt-get`