### PR TITLE
Remove hero picto

### DIFF
--- a/templates/tour.html
+++ b/templates/tour.html
@@ -10,9 +10,6 @@
         <h1>Take a tour</h1>
         <p class="p-heading--three" itemprop="description">Take a tour and get an overview of MAAS, including new features from the latest release.</p>
       </div>
-      <div class="col-4 prefix-2">
-        <img src="{{ ASSET_SERVER_URL }}381e216f-MAAS-GUI.svg?w=154" width="154" alt="MAAS user interface icon" />
-      </div>
     </div>
 </section>
 


### PR DESCRIPTION
## Done

Remove SUSE logo from home page as per copy doc

## QA

./run serve and go to http://0.0.0.0:8006/ and make sure the SUSE logo has gone from the 'The smartest way to manage bare metal' section.

## Issue / Card

Card: https://app.zenhub.com/workspace/o/canonicalltd/maas-design/issues/250
Doc: https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit?ts=59f0bf2e#heading=h.hzentkmd79e7