### PR TITLE
Remove suse logo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -167,9 +167,6 @@
 					<li class="p-inline-images__item">
 						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}eda6b94a-redhat-logo.svg" alt="Redhat logo">
 					</li>
-					<li class="p-inline-images__item">
-						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}59190d38-suse_logo.svg" alt="Suse logo">
-					</li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
## Done

Remove SUSE logo from home page as per copy doc

## QA

./run serve and go to http://0.0.0.0:8006/ and make sure the SUSE logo has gone from the 'The smartest way to manage bare metal' section.

## Issue / Card

Card: https://app.zenhub.com/workspace/o/canonicalltd/maas-design/issues/250
Doc: https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit?ts=59f0bf2e#heading=h.hzentkmd79e7

Fixes: https://github.com/CanonicalLtd/MAAS-design/issues/250