### PR TITLE
Fix docs redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,3 +1,3 @@
 docs: https://docs.ubuntu.com/maas/
-docs/(?P<docs>.*): https://docs.ubuntu.com/maas/2.3/{docs}
+docs/(?P<docs>.*): http://docs.ubuntu.com/maas/2.1/en/{docs}
 get-started: "/install"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 canonicalwebteam.versioned-static==1.0.1
-canonicalwebteam.yaml-redirects==1.0.2
+canonicalwebteam.yaml-redirects==1.0.5
 canonicalwebteam.get-feeds==0.1.7
 Django==1.11.1
 django-versioned-static-url==0.1


### PR DESCRIPTION
Redirects for old docs were originally intended for MAAS 2.1 - e.g. http://maas.io/docs/installconfig-server-iso (which exists on https://www.google.co.uk/url?sa=t&rct=j&q=&esrc=s&source=web&cd=6&cad=rja&uact=8&ved=0ahUKEwiAq9fR6NTXAhUJI8AKHRUyCNAQFghEMAU&url=https%3A%2F%2Fgithub.com%2FCanonicalLtd%2Fmaas-docs%2Fissues%2F112&usg=AOvVaw1Lvk4nF8JQvU9PNzCReVrE) doesn't exist in the 2.2 or 2.3 sets.

So I think old docs links should redirect to docs.ubuntu.com/maas/2.1.

I've also fixed the intellegent docs redirecting, which was broken, by using yaml-redirects v1.0.5.

QA
--

``` bash
$ ./run serve --detach
$ curl -sI http://127.0.0.1:8000/docs/installconfig-server-iso | grep Location
Location: http://docs.ubuntu.com/maas/2.1/en/installconfig-server-iso
$ curl -sI http://127.0.0.1:8000/docs/ | grep Location
Location: http://docs.ubuntu.com/maas/2.1/en/
```

Check those URLs above also redirect correctly in a browser.