### PR TITLE
Remove Ubuntu OpenStack Interoperability lab logo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -217,7 +217,7 @@
 
   <section class="p-strip--light is-deep">
 		<div class="row">
-  		<div class="col-12">
+  		<div class="col-12 prefix-2 suffix-2">
 				<h2 class="p-muted-heading u-align--center">MAAS is used by</h2>
 				<ul class="p-inline-images">
 					<li class="p-inline-images__item">
@@ -228,9 +228,6 @@
 					</li>
 					<li class="p-inline-images__item">
 						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}040783dd-verizon-logo.png" alt="Verizon logo" />
-					</li>
-					<li class="p-inline-images__item">
-						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}0f6861b9-oil-logo.png" alt="OpenStack Interoperability Lab">
 					</li>
 					<li class="p-inline-images__item">
 						<img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}3c7e83fc-atandt-logo.svg" alt="AT&amp;T logo" />

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -79,9 +79,6 @@
             <li class="p-inline-images__item p-inline-images__item--compact">
               <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}cba50650-logo-verizon.svg"  alt="Verizon logo">
             </li>
-            <li class="p-inline-images__item p-inline-images__item--compact">
-              <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}0f6861b9-oil-logo.png?w=145" alt="OpenStack Interoperability Lab">
-            </li>
           </ul>
       </div>
     </div>


### PR DESCRIPTION
## Done
Removed the Ubuntu OIL logo from both home pages

## QA
- Pull this branch
- Run `./run`
- Go to http://0.0.0.0:8006/
- Scroll to the "MAAS is used by" section
- Check there is no Ubuntu OIL logo
- Go to http://0.0.0.0:8006/index2
- Scroll to the "MAAS for enterprise" section
- Check there is no Ubuntu OIL logo

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/216