### PR TITLE
Improve the abbr pattern

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -72,3 +72,10 @@ p {
     max-width: none;
   }
 }
+
+// XXX Ant: 27.02.18 This can be removed when this is fixed
+// https://github.com/vanilla-framework/vanilla-framework/issues/1602
+abbr[title] {
+  border-bottom: .1em dotted;
+  text-decoration: none;
+}

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -77,5 +77,6 @@ p {
 // https://github.com/vanilla-framework/vanilla-framework/issues/1602
 abbr[title] {
   border-bottom: .1em dotted;
+  cursor: help;
   text-decoration: none;
 }

--- a/templates/how-it-works.html
+++ b/templates/how-it-works.html
@@ -46,7 +46,7 @@
     <div class="row u-equal-height">
         <div class="col-8">
             <h2>Protocols</h2>
-            <p>MAAS uses standard server <abbr title="Baseboard Management Controller">BMC</abbr> and <abbr title="Network Interface Controller">NIC</abbr> services such as <abbr title="Intelligent Platform Management Interface">IPMI</abbr> and PXE to control the machines in your data centre. For converged infrastructure, MAAS talks to the chassis controller of the rack or hyperscale chassis such as Intel RSD, Cisco UCS or HP Moonshot. Custom plugins extend MAAS for alternative BMC protocols.</p>
+            <p>MAAS uses standard server <abbr title="Baseboard Management Controller">BMC</abbr> and <abbr title="Network Interface Controller">NIC</abbr> services such as <abbr>IPMI</abbr> and PXE to control the machines in your data centre. For converged infrastructure, MAAS talks to the chassis controller of the rack or hyperscale chassis such as Intel RSD, Cisco UCS or HP Moonshot. Custom plugins extend MAAS for alternative BMC protocols.</p>
             <p>Initial machine inventory and commissioning is done from an ephemeral Ubuntu image that works across all major servers from all major vendors. It is possible to add custom scripts for firmware updates and reporting.</p>
         </div>
         <div class="prefix-1 col-4 u-vertically-center">
@@ -96,7 +96,7 @@
       <div class="col-7"><i></i>
 
           <h3 class="p-heading--five">New</h3>
-          <p>New machines which PXE-boot on a MAAS network will be enlisted automatically if MAAS can detect their BMC parameters. The easiest way to enlist standard <abbr title="Intelligent Platform Management Interface">IPMI</abbr> servers is simply to PXE-boot them on the MAAS network.</p>
+          <p>New machines which PXE-boot on a MAAS network will be enlisted automatically if MAAS can detect their BMC parameters. The easiest way to enlist standard <abbr>IPMI</abbr> servers is simply to PXE-boot them on the MAAS network.</p>
 
           <h3 class="p-heading--five">Commissioning</h3>
           <p>Detailed inventory of RAM, CPU, disks, NICs and accelerators like GPUs itemised and usable as constraints for machine selection. It is possible to run your own scripts for site-specific tasks such as firmware updates.</p>


### PR DESCRIPTION
## Done
Removed duplicated `abbr` in the same document. Increased the space between the border and the baseline of the `abbr` pattern.

## QA
- Go to `/install`
- See that the `abbr` styling is easier to read

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/204
