### PR TITLE
Make the links to docs in the footer evergreen

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -13,7 +13,7 @@
                     <a class="p-link--strong" href="/how-it-works">How it works</a>
                 </li>
                 <li class="p-list__item">
-                    <a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/maas/2.3/en/">Docs</a>
+                    <a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/maas/en/">Docs</a>
                 </li>
                 <li class="p-list__item">
                     <a class="p-link--strong"  href="/tour">Tour</a>
@@ -46,7 +46,7 @@
                     <a class="p-link--external p-link--strong" href="https://launchpad.net/maas">Launchpad</a>
                 </li>
                 <li class="p-list__item">
-                    <a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/maas/2.3/en/contributing-writing">Contribute to documentation</a>
+                    <a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/maas/en/contributing-writing">Contribute to documentation</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Done
Updated the links to docs from the footer to be evergreen and always redirect to the latest version.

## QA
- Scroll to the footer
- Click the link "Contribute to documentation" and check it goes to the docs correctly
- Click the link "Docs" under the MAAS title in the footer and check that goes to docs correctly

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/186
