### PR TITLE
Add Dockerfile for production containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:xenial
+
+# System dependencies
+RUN apt-get update && apt-get install --yes python3-pip
+
+# Python dependencies
+ENV LANG C.UTF-8
+RUN pip3 install --upgrade pip
+RUN pip3 install pipenv talisker
+
+# Import code, install code dependencies
+WORKDIR /srv
+ADD . .
+RUN pipenv install --system --deploy --three
+
+# Set git commit ID
+ARG COMMIT_ID
+RUN test -n "${COMMIT_ID}"
+RUN echo "${COMMIT_ID}" > version-info.txt
+
+# Setup commands to run server
+ENTRYPOINT ["talisker.gunicorn", "webapp.wsgi", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
+CMD ["0.0.0.0:80"]
+

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -64,24 +64,3 @@ TEMPLATES = [
         },
     },
 ]
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'error_file': {
-            'level': 'ERROR',
-            'filename': os.path.join(BASE_DIR, 'django-error.log'),
-            'class': 'logging.handlers.RotatingFileHandler',
-            'maxBytes': 1 * 1024 * 1024,
-            'backupCount': 2
-        }
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['error_file'],
-            'level': 'ERROR',
-            'propagate': True
-        }
-    }
-}


### PR DESCRIPTION
**Based off 228 - review that first**

This Dockerfile will build the image to be used in production in
Kubernetes.

It makes use of talisker.gunicorn, which gives us prettier logging and
version control headers in the response.

QA
--

``` bash
./run build docker build --build-arg COMMIT_ID=`git rev-parse HEAD` --tag
maas . docker run -ti -p 80:80 maas
```

Now go to `http://127.0.0.1` - you should see the site.

In the terminal you should see mention of `talisker`, and if you do:

``` bash
curl -I http://0.0.0.0:80
```

You should see:

``` bash
X-VCS-Revision: 094c11031273577cc4ceb54eb3f885e5474f4ed2
```