### PR TITLE
Update the favicon with a much smaller version

### DIFF
--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -4,7 +4,8 @@
 <meta name="author" content="Canonical" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<link rel="shortcut icon" href="{{ ASSET_SERVER_URL }}55e92155-maas.ico" type="image/x-icon" />
+<link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
+<link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />
 
 <!-- stylesheets -->
 <link href='https://fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic%7CUbuntu+Mono' rel='stylesheet' type='text/css' />

--- a/templates/includes/head.html
+++ b/templates/includes/head.html
@@ -4,8 +4,8 @@
 <meta name="author" content="Canonical" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
-<link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />
+<link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}6284d208-maas-favicon-16px.png" sizes="16x16" />
+<link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}5922a009-maas-favicon-32px.png" sizes="32x32" />
 
 <!-- stylesheets -->
 <link href='https://fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic%7CUbuntu+Mono' rel='stylesheet' type='text/css' />


### PR DESCRIPTION
## Done
Updated the favicon offered by the site from a 352KB file to a 50KB file. Every bite counts.

## QA
- Run `./run`
- Go to http://0.0.0.0:8006/
- Check the favicon appears
- See the file size difference
