### PR TITLE
Remove the P wrapping the homepage company diagram

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -306,7 +306,7 @@
   </div>
   <div class="row is-bordered">
     <div class="col-12">
-      <p><img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}bc176a27-logos-os-and-hw.png?w=1400" alt="Ubuntu, Redhat, CentOS, Windows on IBM, HP, Lenovo, Quanta Cloud Technology, Dell, Open Compute Project, Huawei, Cisco"></p>
+      <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}bc176a27-logos-os-and-hw.png?w=1400" alt="Ubuntu, Redhat, CentOS, Windows on IBM, HP, Lenovo, Quanta Cloud Technology, Dell, Open Compute Project, Huawei, Cisco">
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

Removed the <p> tag that was wrapping the diagram on the homepage and limiting its width.

## QA

 - Go to the home page and see that the image in the "Any OS image — on any hardware" row is full width at all viewports.