### PR TITLE
Update insights links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -419,17 +419,17 @@
   <div class="row">
     <div class="col-12">
       <h2 class="p-link--external p-muted-heading">
-        <a class="p-link--strong" aria-label="External link to find more MAAS news from Ubuntu Insights" href="https://insights.ubuntu.com/tag/maas">The latest MAAS news</a>
+        <a class="p-link--strong" aria-label="External link to find more MAAS news from the Ubuntu blog" href="https://blog.ubuntu.com/tag/maas">The latest MAAS news</a>
       </h2>
     </div>
   </div>
   <div class="row">
     <div id="insights-cloud-feed" class="p-divider">
-      {% get_rss_feed "https://insights.ubuntu.com/tag/maas/feed" limit=3 as insights_feed %}
+      {% get_rss_feed "https://blog.ubuntu.com/tag/maas/feed" limit=3 as insights_feed %}
       {% if insights_feed %}
         {% for item in insights_feed %}
           <article class="col-4 p-divider__block">
-            <h3 class="p-heading--four"><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'maas.io homepage news link', 'eventLabel' : '{{ item.title|escapejs }}', 'eventValue' : '{{ item.link }}' });">{{ item.title }}</a></h3>
+            <h3 class="p-heading--four"><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'maas.io homepage news link', 'eventLabel' : '{{ item.title|escapejs }}', 'eventValue' : '{{ item.link }}' });">{{ item.title }}</a></h3>
             <footer>
               <time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time>
             </footer>


### PR DESCRIPTION
## Done

Update insights links to blog.ubuntu.com

## QA
- Go to latest news section near bottom of page
- Make sure all links go to blog.ubuntu.com instead of insights.ubuntu.com

## Issue / Card

Fixes [#515](https://github.com/ubuntudesign/web-squad/issues/515)
