### PR TITLE
Update copy and links to MAAS 2.4 and Ubuntu 18.04

### DIFF
--- a/templates/install.html
+++ b/templates/install.html
@@ -33,7 +33,7 @@
                   <span class="p-list-step__bullet">2</span>
                   Install Ubuntu Server
                 </h3>
-                <p class="p-list-step__content"><a aria-label="External link to download Ubuntu Server 16.04 LTS" href="http://www.ubuntu.com/download/server" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download Ubuntu Server', 'eventAction' : 'Click', 'eventLabel' : 'Download Ubuntu Server 16.04 LTS' });" class="p-link--external">Download Ubuntu Server 16.04 LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
+                <p class="p-list-step__content"><a aria-label="External link to download Ubuntu Server 16.04 LTS" href="http://www.ubuntu.com/download/server" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download Ubuntu Server', 'eventAction' : 'Click', 'eventLabel' : 'Download Ubuntu Server 16.04 LTS' });" class="p-link--external">Download Ubuntu Server 18.04 LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
               </li>
               <li class="p-list-step__item">
                 <h3 class="p-list-step__title">
@@ -59,7 +59,7 @@
                 <div class="p-list-step__content">
                   <p>Create your admin credentials by typing.</p>
                   <p class="p-code-snippet">
-                      <input class="p-code-snippet__input" value="sudo maas createadmin" readonly="readonly">
+                      <input class="p-code-snippet__input" value="sudo maas init" readonly="readonly">
                       <button class="p-code-snippet__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
                   </p>
                   <p>Login to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
@@ -117,7 +117,7 @@
                   <p><a href="{{ ASSET_SERVER_URL }}5b3a3cd7-Turn+on+DHCP+Copy.jpg" class="venobox venobox--expand" data-gall="installGallery" title="The node listing page in MAAS">
                       <img src="{{ ASSET_SERVER_URL }}5b3a3cd7-Turn+on+DHCP+Copy.jpg?w=552" class="p-image--bordered" alt="MAAS node listing">
                   </a></p>
-                  <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>
+                  <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.4/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>
                 </div>
               </li>
             </ol>


### PR DESCRIPTION
## Done

Updated page content:
 - Ubuntu 16.04 LTS to 18.04 LTS
 - Post-install command updated
 - Link to latest docs updated

## QA

 - Open the [install page](http://localhost:8006/install)
 - Compare it to the [copy doc](https://docs.google.com/document/d/1uVdX719h32QuWT0Dwe_hZTFuCvi4b3XQOcOoQtINH88/edit)
