### PR TITLE
Stop heading from wrapping

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -89,7 +89,7 @@
   <div class="row">
     <div class="row is-bordered u-no-padding--top">
       <div class="col-12">
-        <h2 class="u-no-margin--bottom">Tackle your provisioning problems with MAAS</h2>
+        <h2 class="u-no-margin--bottom" style="max-width: 100%;">Tackle your provisioning problems with MAAS</h2>
       </div>
     </div>
     <div class="row is-bordered">


### PR DESCRIPTION
## Done

Stopped the "Tackle your provisioning problems with MAAS" heading from wrapping on the homepage

## QA

View the homepage and see that "Tackle your provisioning problems with MAAS" is not wrapping