### PR TITLE
Stop hardcoding links in these pages

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -232,7 +232,7 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}5626be9e-chassis-mangement.svg" alt="Chassis icon" />
               <h4 class="p-heading-icon__title">
-                <a class="p-link--strong p-heading--five p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/nodes-comp-hw" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Chassis management' });">Chassis management</a>
+                <a class="p-link--strong p-heading--five p-link--external" href="https://docs.maas.io/en/nodes-comp-hw" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Chassis management' });">Chassis management</a>
               </h4>
             </div>
             <p>Full chassis convergence, including Cisco UCS, HP Moonshot, Intel RSD and more.</p>
@@ -287,7 +287,7 @@
               <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}81ca0037-manage.svg" alt="Manage icon" />
               <h4 class="p-heading-icon__title"><a class="p-link--strong p-heading--five" href="/tour#hardware-tracking" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Service tracking' });"><span>Manage</span>&nbsp;&rsaquo;</a></h4>
             </div>
-            <p>Comes with a <a aria-label="External link to go to MAAS API docs" href="https://docs.ubuntu.com/maas/2.3/en/api" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" class="p-link--external">REST <abbr title="Application Programming Interface">API</abbr></a>, Web <abbr title="User Interface">UI</abbr> and <a aria-label="External link to go to MAAS CLI docs" href="https://docs.ubuntu.com/maas/2.3/en/manage-cli" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" class="p-link--external"><abbr title="Command Line Interface">CLI</abbr></a>.</p>
+            <p>Comes with a <a aria-label="External link to go to MAAS API docs" href="https://docs.maas.io/en/api" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" class="p-link--external">REST <abbr title="Application Programming Interface">API</abbr></a>, Web <abbr title="User Interface">UI</abbr> and <a aria-label="External link to go to MAAS CLI docs" href="https://docs.maas.io/maas/en/manage-cli" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" class="p-link--external"><abbr title="Command Line Interface">CLI</abbr></a>.</p>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
The docs.maas.io site can redirect to the latest version. hardcoding versions in this page just means people are served old links and it pollutes search.

## Done

Changed all links to specific versions of docs to point to the actual docs site, which will redirect to the latest version of those pages

## QA

Check the changed links resolve to valid, expected pages
