### PR TITLE
Entrypoint for talisker gevent workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:bionic
 
+# Set up environment
+ENV LANG C.UTF-8
+WORKDIR /srv
+
 # System dependencies
 RUN apt-get update && apt-get install --yes python3-pip
 
-# Python dependencies
-ENV LANG C.UTF-8
-
 # Import code, install code dependencies
-WORKDIR /srv
 ADD . .
 RUN pip3 install -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 # System dependencies
 RUN apt-get update && apt-get install --yes python3-pip
 
 # Python dependencies
 ENV LANG C.UTF-8
-RUN pip3 install --upgrade pip
 
 # Import code, install code dependencies
 WORKDIR /srv
 ADD . .
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Set git commit ID
 ARG COMMIT_ID
@@ -18,6 +17,6 @@ RUN test -n "${COMMIT_ID}"
 RUN echo "${COMMIT_ID}" > version-info.txt
 
 # Setup commands to run server
-ENTRYPOINT ["talisker.gunicorn", "webapp.wsgi", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
+ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]
 

--- a/entrypoint
+++ b/entrypoint
@@ -2,5 +2,5 @@
 
 set -e
 
-talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --worker-class gevent --error-logfile - --bind $1
+talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --workers 3 --worker-class gevent --error-logfile - --bind $1
 

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+set -e
+
+talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --worker-class gevent --error-logfile - --bind $1
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
     "clean": "rm -rf node_modules yarn-error.log static/css *.log *.sqlite _site/ build/ .jekyll-metadata",
     "watch": "node-sass --include-path node_modules --source-map true --watch static/sass --output static/css",
-    "serve": "talisker.gunicorn webapp.wsgi --reload --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
+    "serve": "./entrypoint 0.0.0.0:${PORT}",
     "build": "node-sass --include-path node_modules static/sass --output static/css"
   },
   "author": "Canonical webteam",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ lockfile==0.12.2
 requests==2.10.0
 requests-cache==0.4.12
 whitenoise==3.3.0
-talisker==0.9.6
+talisker==0.9.13
+gunicorn[gevent]


### PR DESCRIPTION
Fixes https://github.com/ubuntudesign/base-squad/issues/102

QA
--

``` bash
./run
```

See that it mentions "Booting worker" 3 times. Go to http://localhost:8006 and check the site works. Now:

``` bash
docker build --tag maas --build-arg COMMIT_ID=`git rev-parse HEAD` .
docker run -ti -p 8099:80 maas
```

See that it mentions "Booting worker" 3 times. Go to http://localhost:8099 and check the site still works.

Also, check the `X-VCS-Revision` shows correctly:

``` bash
$ curl -Is localhost:8099 | grep VCS
X-VCS-Revision: {commit_hash}
```