### PR TITLE
Update index page styling and copy

### DIFF
--- a/static/sass/_patterns_fluid-grid.scss
+++ b/static/sass/_patterns_fluid-grid.scss
@@ -1,0 +1,43 @@
+// Can be removed once added upstream in Vanilla
+@mixin maas-p-fluid-grid {
+  %fluid-grid {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+  }
+
+  .p-fluid-grid {
+    @extend %fluid-grid;
+  }
+
+  // default fluid-grid item
+  // small screen:  1 item per row (full width)
+  // medium:        2 items per row
+  // > medium:      4 items per row
+  .p-fluid-grid__item {
+    width: 100%; // default to full width
+
+    @media screen and (min-width: $breakpoint-small) {
+      width: 50%; // half width for medium screens
+    }
+
+    @media screen and (min-width: $breakpoint-navigation-threshold) {
+      width: 21.875%; // 4 items per row = col-3
+    }
+  }
+
+  // small fluid-grid item
+  // small screen:   4 items in a row (min width 150px)
+  // larger screens: 6 items in a row (min width 150px)
+  .p-fluid-grid__item--small {
+    // by default use col-3 width (4 items in a row)
+    min-width: 150px;
+    width: 21.875%;
+
+    // on larger screens use col-2 width (6 items in a row)
+    @media screen and (min-width: $breakpoint-small) {
+      width: 15.04854%; // col-2
+    }
+  }
+}

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -13,7 +13,8 @@
 'patterns_modal',
 'patterns_navigation',
 'patterns_takeunders',
-'patterns_inline-images';
+'patterns_inline-images',
+'patterns_fluid-grid';
 
 // patterns
 @include maas-p-footer;
@@ -24,6 +25,7 @@
 @include maas-p-navigation;
 @include maas-p-takeunders;
 @include maas-p-inline-images;
+@include maas-p-fluid-grid;
 
 h1,
 .p-heading--one,
@@ -38,22 +40,6 @@ h2,
   width: map-get($icon-sizes, social);
 }
 
-.u-min-margin--bottom {
-  &h2,
-  &.p-heading--two {
-    margin-bottom: $sp-unit - map-get($nudges, nudge--h2);
-  }
-
-  &h4,
-  &.p-heading--four {
-    margin-bottom: - map-get($nudges, nudge--h4); // the nudge on h4 is .05rem, so no need to subtract an sp-unit from it
-  }
-
-  &[class^='p-button'] {
-    margin-bottom: $spv-nudge-compensation;
-  }
-}
-
 @media only screen and (max-width: $breakpoint-medium) {
   .usabilla_live_button_container { // sass-lint:disable-line class-name-format
     left: calc(90% - 30px);
@@ -61,6 +47,7 @@ h2,
 }
 
 // XXX Caleb: Increase spacing between paragraphs by .5rem, to be upstreamed in Vanilla
+// Issue: https://github.com/vanilla-framework/vanilla-framework/issues/2026
 p + p:not(.p-muted-heading) {
   margin-top: -#{$sp-unit};
 }
@@ -78,4 +65,10 @@ p + p:not(.p-muted-heading) {
 // Issue: https://github.com/vanilla-framework/vanilla-framework/issues/2045
 [class^='p-strip'].is-bordered {
   margin-bottom: inherit;
+}
+
+// XXX Caleb: abbr pattern should have help cursor instead of pointer
+// Issue: https://github.com/vanilla-framework/vanilla-framework/issues/1962
+abbr[title] {
+  cursor: help;
 }

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="p-footer">
     <div class="row">
         <div class="col-4">
-            <h3 class="p-footer__title p-heading--six">MAAS</h3>
+            <h3 class="p-footer__title p-heading--four">MAAS</h3>
             <ul class="p-footer__list p-list">
                 <li class="p-list__item">
                     <a class="p-link--strong" href="/">Home</a>
@@ -22,7 +22,7 @@
         </div>
 
         <div class="col-4">
-            <h3 class="p-footer__title p-heading--six">Need help?</h3>
+            <h3 class="p-footer__title p-heading--four">Need help?</h3>
             <ul class="p-footer__list p-list">
                 <li class="p-list__item">
                     <a class="p-link--external p-link--strong" href="https://askubuntu.com/questions/tagged/maas">Ask Ubuntu</a>
@@ -40,7 +40,7 @@
         </div>
 
         <div class="col-4">
-            <h3 class="p-footer__title p-heading--six">Contribute</h3>
+            <h3 class="p-footer__title p-heading--four">Contribute</h3>
             <ul class="p-footer__list p-list">
                 <li class="p-list__item">
                     <a class="p-link--external p-link--strong" href="https://launchpad.net/maas">Launchpad</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,13 +7,16 @@
 
 {% block content %}
 <!-- Hero banner -->
-<section class="u-image-position p-strip--image is-dark is-bordered" style="overflow: hidden; background-color: #111; background-image:url('{{ ASSET_SERVER_URL }}d7047b19-maas+hero-background--no-left-edge.png'); background-size: 1440px 1440px; background-position: 50% 0; background-repeat: no-repeat;">
-  <div class="row u-equal-height">
+<section class="u-image-position p-strip--image is-dark is-deep" style="overflow: hidden; background-color: #111; background-image:url('{{ ASSET_SERVER_URL }}d7047b19-maas+hero-background--no-left-edge.png'); background-size: 1440px 1440px; background-position: 50% 0; background-repeat: no-repeat;">
+  <div class="row">
     <div class="col-6">
-      <h1 class="p-heading--four">Metal as a Service:</h1>
-      <h2 class="p-heading--two">Say hello to your physical&nbsp;cloud</h2>
-      <p itemprop="description" class="p-heading--five">Complete automation of your physical servers for amazing data centre operational efficiency. On premises, open source and supported.</p>
-      <p><a style="margin-right: 1rem;" aria-label="Find out how to install MAAS" href="/install" class="p-button--positive" itemprop="url" >Install MAAS</a> <a href="/how-it-works" class="p-button--neutral">See how it works</a></p>
+      <h1>Very fast <br class="u-hide--small u-hide--medium" />server provisioning</h1>
+      <p>Self-service, remote installation of Windows, CentOS, and Ubuntu on real servers turns your data center into a bare metal cloud.</p>
+      <p class="u-sv1">Welcome to metal-as-a-service.</p>
+      <div>
+        <a aria-label="Find out how to install MAAS" href="/install" class="p-button--positive" itemprop="url">Install MAAS</a>
+        <a href="/how-it-works" class="p-button--neutral">See how it works</a>
+      </div>
     </div>
     <div class="col-6 p-hero-video">
       <a href="#" aria-label="Watch the MAAS video on YouTube" class="p-hero-video__link"  onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Video', 'eventAction' : 'Play', 'eventLabel' : 'Watch the MAAS video' });">
@@ -38,279 +41,416 @@
   </div>
 </section>
 
-<section class="p-strip p-strip--light is-deep">
+<section class="p-strip--light">
   <div class="row">
-    <div class="col-5">
-      <h2 class="u-no-margin--bottom">The smartest way to manage bare metal</h2>
-    </div>
-    <div class="col-7 prefix-1">
-      <p class="p-heading--five">Get the flexibility of the cloud and the efficiency of physical servers. MAAS is designed for devops at scale, in places where bare metal is the best way to run your app. Big data, private cloud, PAAS and HPC all thrive on MAAS.</p>
-      <p><a href="https://pages.ubuntu.com/eBook-MAAS.html?source=maas_page&medium=Banner&campaign=MAAS_ebook&_ga=2.22106171.1851959601.1510602087-405342743.1460033629" class="p-link--external" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about server provisioning with MAAS' });">Learn more about server provisioning with MAAS</a></p>
+    <h3 class="p-muted-heading u-align-text--center">A selection of customers</h3>
+    <div class="p-fluid-grid">
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}d8f890fb-logo-at%26t.svg" alt="AT&T logo" />
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}4589dd76-logo-deutsche-telekom.svg" alt="Deutsche Telekom logo" />
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}c15698ab-logo-microsoft.svg" alt="Microsoft logo" />
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}e4aa11e6-logo-nec.svg" alt="NEC logo" />
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}cd22a35e-logo-ntt.svg" alt="NTT logo" />
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}cba50650-logo-verizon.svg"  alt="Verizon logo" />
+      </span>
     </div>
   </div>
 </section>
 
-<section class="p-strip is-deep">
-  <div class="row p-divider">
-    <div class="u-equal-height">
-      <div class="col-6 p-divider__block u-vertically-center">
-          <div>
-            <h2>MAAS for enterprise</h2>
-            <p class="p-heading--five">Many enterprises have adopted MAAS for data centre management (DCM) by automating and optimising provisioning for production hardware. MAAS can solve the challenges your business faces.</p>
-          </div>
-      </div>
-      <div class="col-6 p-divider__block u-vertically-center">
-          <ul class="p-inline-images">
-            <li class="p-inline-images__item p-inline-images__item--compact">
-              <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}d8f890fb-logo-at%26t.svg" alt="AT&T logo">
-            </li>
-            <li class="p-inline-images__item p-inline-images__item--compact">
-              <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4589dd76-logo-deutsche-telekom.svg" alt="Deutsche Telekom logo">
-            </li>
-            <li class="p-inline-images__item p-inline-images__item--compact">
-              <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}c15698ab-logo-microsoft.svg" alt="Microsoft logo">
-            </li>
-            <li class="p-inline-images__item p-inline-images__item--compact">
-              <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}e4aa11e6-logo-nec.svg" alt="NEC logo">
-            </li>
-            <li class="p-inline-images__item p-inline-images__item--compact">
-              <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}cd22a35e-logo-ntt.svg" alt="NTT logo">
-            </li>
-            <li class="p-inline-images__item p-inline-images__item--compact">
-              <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}cba50650-logo-verizon.svg"  alt="Verizon logo">
-            </li>
-          </ul>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip p-strip--light is-deep">
+<section class="p-strip">
   <div class="row">
-    <div class="row is-bordered u-no-padding--top">
-      <div class="col-12">
-        <h2 class="u-no-margin--bottom" style="max-width: 100%;">Tackle your provisioning problems with MAAS</h2>
-      </div>
-    </div>
-    <div class="row is-bordered">
-      <div class="col-4">
-        <h3 class="p-heading--four u-no-margin--top u-no-padding--top">Automated operations</h3>
-      </div>
-
-      <div class="col-8">
-        <div class="row is-bordered">
-          <div class="col-2">
-            <h4 class="p-heading--five">Big data</h4>
-          </div>
-          <div class="col-6">
-            <p>Quickly provision and tear down both physical and virtual servers with a modern operating system deployment toolchain. Perfect for high-performance computing (HPC).</p>
-          </div>
-        </div>
-        <div class="row is-bordered">
-          <div class="col-2">
-            <h4 class="p-heading--five">Smart data centres</h4>
-          </div>
-          <div class="col-6">
-            <p>MAAS transforms DevOps with complex server workflows, including dynamic partitioning, application-driven resource scaling, automatic workload rebalancing and immutable infrastructure.</p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-2">
-            <h4 class="p-heading--five">Intelligent hybrid clouds</h4>
-          </div>
-          <div class="col-6">
-            <p>MAAS helps you build unified hybrid cloud operations by exposing a bare-metal provisioning operations API that can be used with service modelling tools, like Juju, or configuration management tools, like Chef. </p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="row is-bordered">
-      <div class="col-4">
-        <h3 class="p-heading--four">Lower cost of operations</h3>
-      </div>
-      <div class="col-8">
-        <div class="row is-bordered">
-          <div class="col-2">
-            <h4 class="p-heading--five">Automated repurposing</h4>
-          </div>
-          <div class="col-6">
-            <p>MAAS helps you run different workloads at different times, using the same or different base operatings systems, at both large and small scales.</p>
-          </div>
-        </div>
-        <div class="row is-bordered">
-          <div class="col-2">
-            <h4 class="p-heading--five">Cost reduction</h4>
-          </div>
-          <div class="col-6">
-            <p>Decommission nodes during non-peak periods to save both energy and personnel requirements. Use the time to focus on day-to-day hardware management tasks, optimising usage patterns and internal processes.</p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-2">
-            <h4 class="p-heading--five">Hardware management</h4>
-          </div>
-          <div class="col-6">
-            <p>Replace legacy in-house provisioning tools and their associated problems, such as development resources, debugging, QA, on-boarding and 'bus-factor', with a standard set of converged open source tools, at speed to any scale.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-4">
-        <h3 class="p-heading--four">Optimised testing</h3>
-      </div>
-      <div class="col-8">
-        <div class="row is-bordered">
-          <div class="col-2">
-            <h4 class="p-heading--five">Continuous integration (CI) testing</h4>
-          </div>
-          <div class="col-6">
-            <p>MAAS's API allows storage and networking to be rapidly reconfigured to match each test case, generating a clean bare metal environment for every run.</p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-2">
-            <h4 class="p-heading--five">Hardware testing at scale</h4>
-          </div>
-          <div class="col-6">
-            <p>Run sets of standard and customised tests on freshly provisioned machines and racks, transforming any new hardware provision and integration process.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- Benifits of MAAS -->
-<section class="p-strip is-deep">
-  <div class="row">
-    <div class="col-12">
-      <h2 class="u-no-margin--bottom">Key features</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <ul class="p-matrix is-trisected">
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}ebcacb5e-automation.svg" alt="Automation cog icon">
-                <h4 class="p-heading-icon__title">
-                  <a class="p-link--strong p-heading--five" aria-label="Learn more about automatic discovery and registration of every device on the network" href="/tour#automation" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' }); dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about device discovery and subnet mapping' });">Automation&nbsp;&rsaquo;</a>
-                </h4>
-            </div>
-            <p>Automatic discovery and registration of every device on the network.</p>
-            <p><abbr title="Baseboard Management Controller">BMC</abbr> (<abbr title="Intelligent Platform Management Interface">IPMI</abbr>, <abbr title="Active Management Techonology">AMT</abbr>, <abbr title="HP Integrated Lights-Out">HPILO</abbr>, <abbr title="Dell Remote Access Controller">DRAC</abbr> and more) and <abbr title="Preboot Execution Environment">PXE</abbr> (<abbr title="Internet Protocol version 4">IPv4</abbr> and <abbr title="Internet Protocol version 6">IPv6</abbr>) automation.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}9a00b936-fast-deployment.svg" alt="Deploymeny in the cloud icon" />
-              <h4 class="p-heading-icon__title">
-                <a class="p-link--strong p-heading--five" href="/tour#fast-deployment" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' }); dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });">Fast deployment&nbsp;&rsaquo;</a>
-              </h4>
-            </div>
-            <p>Zero-touch deployment of Ubuntu, CentOS, Windows and RHEL.</p>
-            <p>Deploy linux distros in less than 5 minutes.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}db3bdf2d-machine-configuration.svg" alt="Machine configuration icon" />
-              <h4 class="p-heading-icon__title">
-                <a class="p-link--strong p-heading--five" href="/tour#configure-servers" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' }); dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });">Machine configuration&nbsp;&rsaquo;</a>
-              </h4>
-            </div>
-            <p>Configure the machine’s network interfaces with bridges, <abbr title="Virtual Local Area Network">VLAN</abbr>s, bonds and more.</p>
-            <p>Create advanced filesystem layouts with <abbr title="Redundant array of independent disks">RAID</abbr>, <abbr title="Block Cache">bcache</abbr>, <abbr title="Logical Volume Management">LVM</abbr> and more.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}5626be9e-chassis-mangement.svg" alt="Chassis icon" />
-              <h4 class="p-heading-icon__title">
-                <a class="p-link--strong p-heading--five p-link--external" href="https://docs.maas.io/en/nodes-comp-hw" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Chassis management' });">Chassis management</a>
-              </h4>
-            </div>
-            <p>Full chassis convergence, including Cisco UCS, HP Moonshot, Intel RSD and more.</p>
-            <p>Dynamic hardware resource management with Intel RSD.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}4e80e2f4-network-management.svg" alt="Network management image" />
-              <h4 class="p-heading-icon__title">
-                <a class="p-link--strong p-heading--five" href="/tour#manage-network" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });">Network management&nbsp;&rsaquo;</a>
-              </h4>
-            </div>
-            <p>Observes and catalogs every IP address on the network (IPAM).</p>
-            <p>Built-in highly available DHCP (active-passive) and DNS (active-active).</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}125c9207-service-tracking.svg" alt="Hardware testing icon" />
-              <h4 class="p-heading-icon__title">
-                <a class="p-link--strong p-heading--five" href="/tour#hardware-testing" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Hardware testing' });">Hardware testing&nbsp;&rsaquo;</a>
-              </h4>
-            </div>
-            <p>Run tests to get up to date information about your hardware&rsquo;s health.</p>
-            <p>Get key metrics for your component&rsquo;s performance.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}14939f84-devops-integration.svg" alt="DevOps image" />
-              <h4 class="p-heading-icon__title"><span class="p-heading--five">DevOps integration</span></h4>
-            </div>
-            <p>Integration with devops automation tools like <a href="https://conjure-up.io/" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'DevOps integration' });" class="p-link--external">conjure-up</a>, <a href="https://jujucharms.com/" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'DevOps integration' });" class="p-link--external">Juju</a>, Chef, Puppet, SALT, Ansible and more.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}c4778eb5-service-tracking.svg" alt="Service tracking image" />
-              <h4 class="p-heading-icon__title"><a class="p-link--strong p-heading--five" href="/tour#hardware-tracking" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Service tracking' });">Service tracking&nbsp;&rsaquo;</a></h4>
-            </div>
-            <p>Monitors and tracks critical services to ensure proper operations.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div class="p-heading-icon">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}81ca0037-manage.svg" alt="Manage icon" />
-              <h4 class="p-heading-icon__title"><a class="p-link--strong p-heading--five" href="/tour#hardware-tracking" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Service tracking' });"><span>Manage</span>&nbsp;&rsaquo;</a></h4>
-            </div>
-            <p>Comes with a <a aria-label="External link to go to MAAS API docs" href="https://docs.maas.io/en/api" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" class="p-link--external">REST <abbr title="Application Programming Interface">API</abbr></a>, Web <abbr title="User Interface">UI</abbr> and <a aria-label="External link to go to MAAS CLI docs" href="https://docs.maas.io/maas/en/manage-cli" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'REST API, CLI' });" class="p-link--external"><abbr title="Command Line Interface">CLI</abbr></a>.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--accent is-deep">
-  <div class="row is-bordered">
     <div class="col-6">
-      <h2>Any OS image &mdash; <br />on any hardware</h2>
+      <h2>Real servers,<br />self-service.</h2>
+    </div>
+    <div class="col-6">
+      <p>You run the data center, but your customers decide what they want to do with the hardware. They love the cloud experience, but it’s more efficient for you to own the hardware.</p>
+      <p>MAAS provides super-fast self-service provisioning of Windows, Ubuntu, CentOS and ESXi.</p>
+      <p>
+        <a href="https://pages.ubuntu.com/eBook-MAAS.html?source=maas_page&medium=Banner&campaign=MAAS_ebook&_ga=2.22106171.1851959601.1510602087-405342743.1460033629" class="p-link--external" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about server provisioning with MAAS' });">Learn more about server provisioning with MAAS</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<div class="p-strip u-no-padding--top u-no-padding--bottom">
+  <div class="row">
+    <hr class="u-no-margin--bottom" />
+  </div>
+</div>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2>Bare-metal,<br />cloud experience.</h2>
+    </div>
+    <div class="col-6">
+      <p>MAAS implements all the standard features of a public cloud &mdash; like instance metadata and cloud-init. Your customers get complete control of the deployed machine.</p>
+      <p>Canonical created cloud-init and leads the project globally; we ensure that MAAS provides a first-class cloud experience for physical servers.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h2>Storage</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h4>Inventory, testing and benchmarking</h4>
+      <p>MAAS detects and inventories all the disks, in every server. You’ll have a single database of every model and serial number.</p>
+      <p>MAAS tests disks either non-destructively, or (destructively) with short or long write cycles &mdash; and learns about their performance.</p>
+    </div>
+    <div class="col-6">
+      <h4>RAID, LVM, Bcache, ZFS and more</h4>
+      <p>Auto-tagging of SSD and rotary disk types makes it easy to know which disks to use for each application.</p>
+      <p>Your users configure the storage of any server they control: RAID, LVM, Bcache, and ZFS. Configure boot, applications, and backup disks exactly where you want them &mdash; and get the installed machine, a few minutes later.</p>
+    </div>
+  </div>
+</section>
+
+<div class="p-strip--light u-no-padding--top u-no-padding--bottom">
+  <div class="row">
+    <hr class="u-no-margin--bottom" />
+  </div>
+</div>
+
+<div class="p-strip--light">
+  <div class="row">
+    <h2>Network</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h4>Detection and configuration</h4>
+      <p>The most error-prone part of data center operations is the network.</p>
+      <p>MAAS enables rapid convergence on a correct network configuration &mdash; for every server, in every rack. All NICs are detected and inventoried when a machine is enlisted in MAAS.</p>
+      <p>Discover the topology of the network &mdash; which NIC is plugged into which port on which switch. MAAS tests access to specific VLANs from each NIC.</p>
+      <p>Network bonds and VLANs can be configured too. Set all significant network operating properties through MAAS &mdash; and then validate that configuration with ephemeral machine booting and testing.</p>
+    </div>
+    <div class="col-6">
+      <h4>Monitoring</h4>
+      <p>MAAS rack controllers provide local endpoints for all infrastructure services in the rack itself, and they also monitor the local network for rogue devices, IP addresses and MAC addresses.</p>
+      <p>Over time, you’ll know if there are ‘extra’ devices plugged into any fabric or VLAN that MAAS is asked to monitor.</p>
+      <p>Solve network mysteries faster with distributed network analysis and observation.</p>
+    </div>
+  </div>
+</div>
+
+<section class="p-strip">
+  <div class="row">
+    <h2>Key features</h2>
+  </div>
+  <div class="row">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}93830fc8-MAAS_icon_Automation.svg" alt="Automation cog icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title">
+            <a class="p-link--strong p-heading--five" aria-label="Learn more about automatic discovery and registration of every device on the network" href="/tour#automation" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' }); dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about device discovery and subnet mapping' });">Automation&nbsp;&rsaquo;</a>
+          </h4>
+          <div class="p-matrix__desc">
+            <p>Automatic discovery and registration of every network device.
+              <abbr title="Baseboard Management Controller">BMC</abbr> ops with
+              <abbr title="Intelligent Platform Management Interface">IPMI</abbr>,
+              <abbr title="Active Management Techonology">AMT</abbr> and other protocols.
+            </p>
+            <p>
+              <abbr title="Preboot Execution Environment">PXE</abbr> over
+              <abbr title="Internet Protocol version 4">IPv4</abbr> and
+              <abbr title="Internet Protocol version 6">IPv6</abbr> networks.
+              APIs for DNS, DHCP, IPAM, server configuration and provisioning.
+            </p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}e0e09ca6-MAAS_icon_Speed.svg" alt="Speed icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title">
+            <a class="p-link--strong p-heading--five" href="/tour#fast-deployment" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about images' }); dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Fast deployment' });">Speed&nbsp;&rsaquo;</a>
+          </h4>
+          <div class="p-matrix__desc">
+            <p>Zero-touch deployment of Ubuntu, CentOS, Windows and RHEL.</p>
+            <p>Full deployment time is approximately two boot cycles plus two minutes for disk imaging.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}8d9ac370-MAAS_icon_Inventory.svg" alt="Inventory icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title">
+            <a class="p-link--strong p-heading--five p-link--external" href="https://docs.maas.io/en/nodes-comp-hw" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Chassis management' });">Inventory</a>
+          </h4>
+          <div class="p-matrix__desc">
+            <p>Discover every PCI and USB device in every server. Inventory disk models and serial numbers. Provision machines based on specific inventory details.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}0ab10d32-MAAS_icon_Storage.svg" alt="Storage layouts icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title">
+            <a class="p-link--strong p-heading--five" href="/tour#configure-servers" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' }); dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });">Storage layouts&nbsp;&rsaquo;</a>
+          </h4>
+          <div class="p-matrix__desc">
+            <p>Create advanced filesystem layouts with
+              <abbr title="Redundant array of independent disks">RAID</abbr>,
+              <abbr title="Block Cache">bcache</abbr>,
+              <abbr title="Logical Volume Management">LVM</abbr>, ZFS and more. Automate storage configuration through APIs. Allocate servers based on storage.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}086349be-MAAS_icon_IPAM.svg" alt="IPAM icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title">
+            <a class="p-link--strong p-heading--five" href="/tour#configure-servers" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about storage' }); dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Machine configuration' });">IPAM, DHCP, DNS&nbsp;&rsaquo;</a>
+          </h4>
+          <div class="p-matrix__desc">
+            <p>Configure server network interfaces with bridges,
+              <abbr title="Virtual Local Area Network">VLAN</abbr>s, bonds and addresses.</p>
+              <p>Integrated, best of breed, highly available, open source DHCP and DNS.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}d3d238c8-MAAS_icon_Hardware+Testing.svg" alt="Hardware testing icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title">
+            <a class="p-link--strong p-heading--five" href="/tour#hardware-testing" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Hardware testing' });">Hardware testing&nbsp;&rsaquo;</a>
+          </h4>
+          <div class="p-matrix__desc">
+            <p>Run tests to get up to date information about hardware health.</p>
+            <p>Benchmark disk, RAM, CPU and network performance.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}77288bc2-MAAS_icon_DevOps+Integration.svg" alt="DevOps icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title">
+            <span class="p-heading--five">DevOps on bare metal</span>
+          </h4>
+          <div class="p-matrix__desc">
+            <p>Integration with Chef, Puppet, SALT, Ansible, Conjure-up, and <a class="p-link--external" href="https://jujucharms.com/">Juju</a>.</p>
+            <p>REST API, CLI and Python bindings enable full lifecycle and project automation.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}454f5853-MAAS_icon_network_monitoring.svg" alt="Network monitoring icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title">
+            <a class="p-link--strong p-heading--five" href="/tour#manage-network" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Network management' });">Network monitoring&nbsp;&rsaquo;</a>
+          </h4>
+          <div class="p-matrix__desc">
+            <p>Continuously observes network traffic, and catalogs every active IP address of unknown origin.</p>
+            <p>Discovers rogue devices, IPs and MAC addresses. Drives active scanning of network ranges.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}b78dd440-MAAS_icon_authenticate.svg" alt="Authentication icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title"><span class="p-heading--five">Authentication & Identity</span></h4>
+          <div class="p-matrix__desc">
+            <p>Integrate with LDAP, Active Directory or SAML for central identity management and single-sign-on across multiple MAAS regions.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}9358a090-MAAS_icon_Composible+Systems.svg" alt="Composable systems icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title"><span class="p-heading--five">Composable systems</span></h4>
+          <div class="p-matrix__desc">
+            <p>Drive Cisco UCS, Intel RSD, HP Moonshot and more. Supports dynamic hardware composition with Intel RSD.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}cb1205a5-MAAS_icon_Cloud+Metadata.svg" alt="Cloud metadata icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title"><span class="p-heading--five">Cloud metadata</span></h4>
+          <div class="p-matrix__desc">
+            <p>Reuse standard cloud operations with cloud-init and metadata services. Hybrid multicloud operations now include bare metal, with no change in applications.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}bbaafa51-MAAS_icon_KVM+Multi-Cloud.svg" alt="KVM Micro-cloud icon" />
+        <div class="p-matrix__content">
+          <h4 class="p-matrix__title"><span class="p-heading--five">KVM micro-cloud</span></h4>
+          <div class="p-matrix__desc">
+            <p>Designate servers to host KVM virtual machines to be dynamically provisioned alongside physical servers.</p>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip--accent is-shallow">
+  <div class="row u-equal-height">
+    <div class="col-10">
+      <h3 class="p-heading--two u-no-margin--bottom">Learn how to configure and install MAAS</h3>
+      <br class="u-hide--medium u-hide--large" />
+    </div>
+    <div class="col-2 u-vertically-center">
+      <a class="p-button--positive p-link--external u-no-margin--bottom" href="https://docs.snapcraft.io/build-snaps/languages">Get Started</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <h2>Your future data center, available now</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h4>Carrier-grade infrastructure DNS, DHCP and IPAM</h4>
+      <p>MAAS integrates best-of-breed ISC DHCP and Bind9 DNS, and will operate these in high availability mode whenever redundant MAAS services are provided.</p>
+      <p>Deploy the MAAS API services on two systems and you will have high availability API endpoints; deploy two rack controllers and all rack services are automatically redundant.</p>
+      <p>MAAS uses the Postgres SQL database which supports redundant and highly available scenarios.</p>
+      <h4>Devops on bare metal is easy with dynamic server provisioning</h4>
+      <p>Take devops to bare metal for apps like big data, Kubernetes, analytics, machine learning, private cloud, OpenStack, PAAS and HPC. The specialists love MAAS.</p>
+    </div>
+    <div class="col-6">
+      <h4>Open source software-defined data center</h4>
+      <p>MAAS is an open source SDDC solution used by telcos, financial institutions, media companies and supercomputer admins to take care of all the low-level details.</p>
+      <p>PXE, IPMI, ILO and all the custom protocols needed for diverse vendor hardware support come together in one clean REST API with Python bindings for easy integration and automation.</p>
+      <p>It includes a full IPAM capabilities, providing a central database and REST API for all network addressing and naming information.</p>
+      <h4>KVM Micro-cloud for edge computing</h4>
+      <p>MAAS provides a simple micro-cloud alongside physical provisioning, suitable for edge cloud operations.</p>
+    </div>
+  </div>
+</section>
+
+
+<section class="p-strip p-strip--light">
+  <div class="row">
+    <h2>Tackle your provisioning problems <br class="u-hide--small u-hide--medium" />with MAAS</h2>
+  </div>
+  <div class="row">
+    <div class="hr"></div>
+  </div>
+  <div class="row is-bordered">
+    <div class="col-4">
+      <h3 class="p-heading--four u-no-margin--top u-no-padding--top">Automated operations</h3>
+    </div>
+    <div class="col-8">
+      <div class="row">
+        <div class="col-2">
+          <h4 class="p-heading--five">Big data</h4>
+        </div>
+        <div class="col-6">
+          <p>Quickly provision and tear down both physical and virtual servers with a modern operating system deployment toolchain. Perfect for high-performance computing (HPC).</p>
+        </div>
+      </div>
+      <div class="row is-bordered">
+        <div class="col-2">
+          <h4 class="p-heading--five">Smart data centres</h4>
+        </div>
+        <div class="col-6">
+          <p>MAAS transforms DevOps with complex server workflows, including dynamic partitioning, application-driven resource scaling, automatic workload rebalancing and immutable infrastructure.</p>
+        </div>
+      </div>
+      <div class="row is-bordered">
+        <div class="col-2">
+          <h4 class="p-heading--five">Intelligent hybrid clouds</h4>
+        </div>
+        <div class="col-6">
+          <p>MAAS helps you build unified hybrid cloud operations by exposing a bare-metal provisioning operations API that can be used with service modelling tools, like Juju, or configuration management tools, like Chef. </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row is-bordered">
+    <div class="col-4">
+      <h3 class="p-heading--four">Lower cost of operations</h3>
+    </div>
+    <div class="col-8">
+      <div class="row">
+        <div class="col-2">
+          <h4 class="p-heading--five">Automated repurposing</h4>
+        </div>
+        <div class="col-6">
+          <p>MAAS helps you run different workloads at different times, using the same or different base operatings systems, at both large and small scales.</p>
+        </div>
+      </div>
+      <div class="row is-bordered">
+        <div class="col-2">
+          <h4 class="p-heading--five">Cost reduction</h4>
+        </div>
+        <div class="col-6">
+          <p>Decommission nodes during non-peak periods to save both energy and personnel requirements. Use the time to focus on day-to-day hardware management tasks, optimising usage patterns and internal processes.</p>
+        </div>
+      </div>
+      <div class="row is-bordered">
+        <div class="col-2">
+          <h4 class="p-heading--five">Hardware and Virtual Machine management</h4>
+        </div>
+        <div class="col-6">
+          <p>Replace legacy in-house provisioning tools and their associated problems, such as development resources, debugging, QA, on-boarding and 'bus-factor', with a standard set of converged open source tools, at speed to any scale.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row is-bordered">
+    <div class="col-4">
+      <h3 class="p-heading--four">Optimised testing</h3>
+    </div>
+    <div class="col-8">
+      <div class="row">
+        <div class="col-2">
+          <h4 class="p-heading--five">Continuous integration (CI) testing</h4>
+        </div>
+        <div class="col-6">
+          <p>MAAS's API allows storage and networking to be rapidly reconfigured to match each test case, generating a clean bare metal environment for every run.</p>
+        </div>
+      </div>
+      <div class="row is-bordered">
+        <div class="col-2">
+          <h4 class="p-heading--five">Hardware testing at scale</h4>
+        </div>
+        <div class="col-6">
+          <p>Run sets of standard and customised tests on freshly provisioned machines and racks, transforming any new hardware provision and integration process.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--accent u-no-padding--bottom">
+  <div class="row">
+    <div class="col-6">
+      <h2>Deploy any OS image <br />on any hardware</h2>
     </div>
     <div class="col-6">
       <p class="p-heading--four">MAAS delivers the fastest OS installation times in the industry thanks to its optimised image-based installer.</p>
     </div>
   </div>
-  <div class="row is-bordered">
-    <div class="col-12">
-      <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}bc176a27-logos-os-and-hw.png?w=1400" alt="Ubuntu, Redhat, CentOS, Windows on IBM, HP, Lenovo, Quanta Cloud Technology, Dell, Open Compute Project, Huawei, Cisco">
-    </div>
-  </div>
+</section>
+
+<section class="p-strip--accent">
   <div class="row">
-      <ul class="p-list u-no-margin--top">
+    <img src="{{ ASSET_SERVER_URL }}bc176a27-logos-os-and-hw.png?w=1400" alt="Ubuntu, Redhat, CentOS, Windows on IBM, HP, Lenovo, Quanta Cloud Technology, Dell, Open Compute Project, Huawei, Cisco" />
+  </div>
+</section>
+
+<section class="p-strip--accent">
+  <div class="row">
+      <ul class="p-list">
         <li class="p-list__item is-ticked is-large col-4 p-heading--five u-no-margin--top">Works on all certified servers from any major vendor</li>
         <li class="p-list__item is-ticked is-large col-4 p-heading--five u-no-margin--top">Discovers servers in racks, chassis and data centre networks</li>
         <li class="p-list__item is-ticked is-large col-4 p-heading--five u-no-margin--top">Supports major system BMCs and chassis controllers</li>
@@ -318,110 +458,100 @@
   </div>
 </section>
 
-<section class="p-strip--light is-deep">
+<section class="p-strip u-no-padding--bottom">
   <div class="row">
-    <div class="col-4">
-      <h2>Enterprise support for MAAS</h2>
+    <div class="col-6">
+      <h2>Enterprise support <br class="u-hide--small" />for MAAS</h2>
     </div>
-    <div class="col-8 prefix-2">
-      <p class="p-heading--five">MAAS is freely available, open source software from Canonical. For large volume and public clouds with dynamic scale, we offer per-region pricing with flexible node ranges.</p>
+    <div class="col-6">
+      <p>MAAS is freely available, open source software from Canonical. For large volume and public clouds with dynamic scale, we offer per-region pricing with flexible node ranges.</p>
     </div>
   </div>
-
-  <div class="row">
-    <div class="col-12" style="overflow-x: auto;">
-      <table style="width: 100%;">
-        <thead>
-          <tr>
-            <td class="u-align--center" style="width: 40%;">&nbsp;</td>
-            <th class="u-align--center" style="width: 20%;">Free</th>
-            <th class="u-align--center" style="width: 20%;">Standard</th>
-            <th class="u-align--center" style="width: 20%;">Advanced</th>
-          <tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Price per machine</td>
-            <td class="u-align--center">$0</td>
-            <td class="u-align--center">$5 per month</td>
-            <td class="u-align--center">
-              $10 per month
-            </td>
-          </tr>
-
-          <tr>
-            <td>Per region per year</td>
-            <td class="u-align--center">-</td>
-            <td class="u-align--center">-</td>
-            <td class="u-align--center">Unlimited machines $75,000</td>
-          </tr>
-
-          <tr>
-            <td>Phone and ticket support</td>
-            <td class="u-align--center">None</td>
-            <td class="u-align--center">8am - 6pm on weekdays</td>
-            <td class="u-align--center">24 hours a day, everyday</td>
-          </tr>
-
-          <tr>
-            <td>Ubuntu and CentOS deployment</td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-          </tr>
-
-          <tr>
-            <td>Landscape Management<br />
-            (for the MAAS servers)</td>
-            <td>&nbsp;</td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-          </tr>
-
-          <tr>
-            <td>Livepatch<br />
-            (for the MAAS servers)</td>
-            <td>&nbsp;</td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-          </tr>
-
-          <tr>
-            <td>Knowledge Base</td>
-            <td>&nbsp;</td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-          </tr>
-
-          <tr>
-            <td>Windows, RHEL, and custom image<br /> creation and deployment</td>
-            <td>&nbsp;</td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-          </tr>
-
-          <tr>
-            <td>High availability (HA) support</td>
-            <td>&nbsp;</td>
-            <td>&nbsp;</td>
-            <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes"></td>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <td>&nbsp;</td>
-            <td class="u-align--center"><a href="/install">Install MAAS&nbsp;&rsaquo;</a></td>
-            <td class="u-align--center"><a href="/contact-us" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });">Contact us&nbsp;&rsaquo;</a></td>
-            <td class="u-align--center"><a href="/contact-us" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });">Contact us&nbsp;&rsaquo;</a></td>
-          </tr>
-        </tfoot>
-      </table>
+  <div class="p-strip">
+    <div class="row">
+      <div class="col-12" style="overflow-x: auto;">
+        <table style="min-width: 380px; width: 100%;">
+          <thead>
+            <tr>
+              <td class="u-align--center" style="width: 40%;">&nbsp;</td>
+              <th class="u-align--center" style="width: 20%;">Free</th>
+              <th class="u-align--center" style="width: 20%;">Standard</th>
+              <th class="u-align--center" style="width: 20%;">Advanced</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Price per machine enlisted in a MAAS plan</td>
+              <td class="u-align--center">$0</td>
+              <td class="u-align--center">$5 per month</td>
+              <td class="u-align--center">$10 per month</td>
+            </tr>
+            <tr>
+              <td>Price per region, per year (unlimited machines)</td>
+              <td class="u-align--center">-</td>
+              <td class="u-align--center">-</td>
+              <td class="u-align--center">Unlimited machines $75,000</td>
+            </tr>
+            <tr>
+              <td>Phone and ticket support</td>
+              <td class="u-align--center">None</td>
+              <td class="u-align--center">8am - 6pm on weekdays</td>
+              <td class="u-align--center">24 hours a day, everyday</td>
+            </tr>
+            <tr>
+              <td>Ubuntu and CentOS deployment</td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+            </tr>
+            <tr>
+              <td>Landscape Management<br />
+              (for the MAAS servers)</td>
+              <td>&nbsp;</td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+            </tr>
+            <tr>
+              <td>Livepatch<br />
+              (for the MAAS servers)</td>
+              <td>&nbsp;</td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+            </tr>
+            <tr>
+              <td>Knowledge Base</td>
+              <td>&nbsp;</td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+            </tr>
+            <tr>
+              <td>Windows, RHEL, and custom image<br /> creation and deployment</td>
+              <td>&nbsp;</td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+            </tr>
+            <tr>
+              <td>High availability (HA) support</td>
+              <td>&nbsp;</td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+              <td class="u-align--center"><img src="{{ ASSET_SERVER_URL }}aeec264b-green-tick.svg" width="16" alt="Yes" /></td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td>&nbsp;</td>
+              <td class="u-align--center"><a href="/install">Install MAAS&nbsp;&rsaquo;</a></td>
+              <td class="u-align--center"><a href="/contact-us" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });">Contact us&nbsp;&rsaquo;</a></td>
+              <td class="u-align--center"><a href="/contact-us" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in Professional', 'eventAction' : 'Click', 'eventLabel' : 'Contact Us' });">Contact us&nbsp;&rsaquo;</a></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
     </div>
   </div>
 </section>
 
-<!-- News -->
-<section class="p-strip--light is-deep">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-12">
       <h2 class="p-link--external p-muted-heading">
@@ -447,4 +577,5 @@
     </div>
   </div>
 </section>
+
 {% endblock %}


### PR DESCRIPTION
## Done

- Updated copy according to [copydoc](https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit#)
- Updated styles (taken from #274)

## QA

- Pull code, run `./run`, navigate to http://0.0.0.0:8006/
- Check that the copy matches the [copydoc](https://docs.google.com/document/d/1Gv3_A3vW2k7U-0B0KVSHkEnGwgtIlDl5P1jGMSc8sqI/edit#)
- Note that the buttons on the hero strip (Install MAAS, See how it works) don't match the copydoc because there isn't currently a `/compare` page yet. Also, the logos in the Key Features matrix are wrong and will be updated when the icons have been finalised. **EDIT:** new icons have been added now
- Check page on large and small screens

## Issue / Card

Fixes #268, fixes #286 
