### PR TITLE
Fix the release-notes link on the tour page

### DIFF
--- a/templates/tour.html
+++ b/templates/tour.html
@@ -59,7 +59,7 @@
                     <li>Periodically</li>
                 </ul>
                 <p>
-                    <a href="https://docs.maas.io/release-notes"
+                    <a href="https://docs.maas.io/en/release-notes"
                        onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' });
                                 dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about device discovery and subnet mapping' });"
                        class="p-link--external"

--- a/templates/tour.html
+++ b/templates/tour.html
@@ -59,7 +59,7 @@
                     <li>Periodically</li>
                 </ul>
                 <p>
-                    <a href="https://docs.maas.io/en/release-notes"
+                    <a href="https://docs.maas.io/en/installconfig-network-dev-discovery"
                        onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Feature', 'eventAction' : 'Click', 'eventLabel' : 'Automation' });
                                 dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Interested in feature', 'eventAction' : 'Click', 'eventLabel' : 'Learn more about device discovery and subnet mapping' });"
                        class="p-link--external"


### PR DESCRIPTION
## Done
Fixed the link to the release-notes in docs on the tour page. Updated the [copy doc](https://docs.google.com/document/d/1KcYwNK0pJyiDVEDq4vTpv6BX_rpSDnxUxtAvAnsRKyw/edit)

## QA
- Go to /tour 
- Check the "Learn more about device discovery and subnet mapping" link goes to the latest release-notes
- See that the copy doc link is correct

## Issue / Card
Fixes https://github.com/canonical-websites/maas.io/issues/297
