### PR TITLE
Use canonicalwebteam.django_views for template finder

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,3 +1,4 @@
 docs: https://docs.maas.io/
 docs/(?P<docs>.*): http://docs.maas.io/{docs}
 get-started: "/install"
+index.html: "/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Django==1.11.16
 django-versioned-static-url==0.1
 django-static-root-finder==0.1
 django-asset-server-url==0.1
-django-template-finder-view==0.2
+canonicalwebteam.django_views==1.3.3
 feedparser==5.2.1
 lockfile==0.12.2
 requests==2.10.0

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1,4 +1,4 @@
-from django_template_finder_view import TemplateFinder
+from canonicalwebteam.django_views import TemplateFinder
 from django.http import HttpResponseNotFound, HttpResponseServerError
 from django.template import loader
 


### PR DESCRIPTION
## Done

- replace `django_template_finder_view` lib with `canonicalwebteam.django_views`

## QA

- `./run`
- http://0.0.0.0:8006/index.html
- Navigate in maas.io it sould still work
- http://0.0.0.0:8006/index.html
- Should return a 404
- http://0.0.0.0:8006/qsdfdsqlfjdsqlkf
- Should return a 404
